### PR TITLE
Update currentPos when seekTo called

### DIFF
--- a/lib/core/fijkplayer.dart
+++ b/lib/core/fijkplayer.dart
@@ -429,11 +429,12 @@ class FijkPlayer extends ChangeNotifier implements ValueListenable<FijkValue> {
     } else if (!isPlayable()) {
       FijkLog.e("$this invoke seekTo invalid state:$state");
       return Future.error(StateError("Non playable state $state"));
-    } else {
-      FijkLog.i("$this invoke seekTo msec:$msec");
-      _seeking = true;
-      _channel.invokeMethod("seekTo", <String, dynamic>{"msec": msec});
     }
+
+    FijkLog.i("$this invoke seekTo msec:$msec");
+    _seeking = true;
+    _channel.invokeMethod("seekTo", <String, dynamic>{"msec": msec});
+    _currentPos = Duration(milliseconds: msec);
   }
 
   /// Release native player. Release memory and resource


### PR DESCRIPTION
The current position is tracked separately from the player and requires
the player to stream an updated position. However, if the player is
paused and seekTo is called, then the currentPos is out of sync with the
players position.

This change explicitly updates the current position being tracked so
that it can be used until the player starts again and updates the
current position.

Signed-off-by: Nick Campbell <nicholas.j.campbell@gmail.com>