### PR TITLE
Remove cover Image's fit=BoxFit.fill attribute

### DIFF
--- a/lib/core/fijkview.dart
+++ b/lib/core/fijkview.dart
@@ -555,10 +555,7 @@ class __InnerFijkViewState extends State<_InnerFijkView> {
       if (widget.cover != null && !value.videoRenderStart) {
         ws.add(Positioned.fromRect(
           rect: pos,
-          child: Image(
-            image: widget.cover!,
-            fit: BoxFit.fill,
-          ),
+          child: Image(image: widget.cover!),
         ));
       }
 


### PR DESCRIPTION
Fix: This attribute will cause the cover image to not be fit like the video content does.